### PR TITLE
bring new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The action mainly includes following features:
 * Now uses authoritative [Spack repository](https://github.com/spack/spack.git).
 * Spack now uses `curl` to download packages and timeout limit is increased to 60 s to prevent fetching issues
 * Spack now could use system installed packages (`spack external find`).
+* Fixed following issue/s: https://github.com/esmf-org/nuopc-comp-testing/issues/2
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ The action mainly includes following features:
 
 ### v1.2
 
-* The extra `mpirun` arguments now need to be passed with `mpirun_arg` input.
+* The extra `mpirun` arguments now need to be passed with `mpirun_arg` input argument.
+* A new `debug` argument is added to the action that allow to create ssh connection to the runner for debugging (uses mxschmitt/action-tmate@v3).
 * Now uses authoritative [Spack repository](https://github.com/spack/spack.git).
 * Spack now uses `curl` to download packages and timeout limit is increased to 60 s to prevent fetching issues
 * Spack now uses system installed packages (`spack external find`).
@@ -52,6 +53,7 @@ Create components `.yml` file in your repositories under `.github/workflows/test
 * `component_build` - The list of shell commands to build the component. This is required since the GitHub Action do not know anything about the component build system and requirements.
 * `component_module_name` - The Fortran module name of the component that will be tested. This argument is currently required but it would be a part of the user provided YAML files.
 * `data_component_name` - The optional name of data component that will be used to force the component. The valid values are `datm` (default), `dice`, `dlnd`, `docn`, `drof` and `dwav`. It would be a part of the user provided YAML files in the future.
+* `debug` - The optional argument for debugging purpose. It triggers extra output and also create ssh connection to the runner for debugging (uses [mxschmitt/action-tmate@v3](https://github.com/mxschmitt/action-tmate)).
 * `dependencies` - The list of dependencies that are used to build the application. Since Spack is used to install dependencies, the given packages need to be part of the Spack distribution. The list of packages can be seen in [here](https://packages.spack.io). The ESMF package (`esmf@8.4.0b15+parallelio`) needs to be added to the list. 
 * `dependencies_install_dir` - An optional path of installation directory for dependencies. The default value is set to `~/.spack-ci`.
 * `mpirun_arg` - The required argument to be passed to `mpirun` command. For example `--oversubscribe -np 6 --mca btl_tcp_if_include eth0` can be passed to run test case on 6 processor (`--oversubscribe` is required for the jobs that needs to be run more then 2 processor and `--mca btl_tcp_if_include eth0` is required to overcome hanging issue of collective communication under GitHub runners).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The action mainly includes following features:
 * A new `debug` argument is added to the action that allow to create ssh connection to the runner for debugging (uses mxschmitt/action-tmate@v3).
 * Now uses authoritative [Spack repository](https://github.com/spack/spack.git).
 * Spack now uses `curl` to download packages and timeout limit is increased to 60 s to prevent fetching issues
-* Spack now uses system installed packages (`spack external find`).
+* Spack now could use system installed packages (`spack external find`).
 
 ## Usage
 

--- a/action.yaml
+++ b/action.yaml
@@ -87,7 +87,6 @@ runs:
 
     # concretize dependencies
     - name: Concretize Spack Environment Using YAML Specification
-      if: ${{ success() }}
       run: |
         $GITHUB_ACTION_PATH/scripts/concretize_deps.sh \
           -a ${{ inputs.architecture }} \
@@ -100,7 +99,6 @@ runs:
     # restore dependencies from cache
     - name: Restore Dependencies
       uses: actions/cache@v3
-      if: ${{ success() }}
       with:
         path: ${{ inputs.dependencies_install_dir }} 
         key: spack-${{ runner.os }}-${{ inputs.architecture }}-${{ hashFiles('**/spack.lock') }}
@@ -109,7 +107,6 @@ runs:
 
     # install dependencies
     - name: Install Dependencies with Spack 
-      if: ${{ success() }}
       run: |
         $GITHUB_ACTION_PATH/scripts/install_deps.sh \
           -i ${{ inputs.dependencies_install_dir }} \
@@ -119,7 +116,6 @@ runs:
     # checkout data models
     - name: Checkout CDEPS
       uses: actions/checkout@v3
-      if: ${{ success() }}
       with:
         repository: uturuncoglu/CDEPS
         path: ${{ inputs.app_install_dir }}/cdeps
@@ -127,7 +123,6 @@ runs:
 
     # build and install data models
     - name: Build and Install CDEPS
-      if: ${{ success() }}
       run: |
         export PATH=${{ inputs.dependencies_install_dir }}/view/bin:$PATH
         export ESMFMKFILE=${{ inputs.dependencies_install_dir }}/view/lib/esmf.mk
@@ -148,7 +143,6 @@ runs:
 
     # build component
     - name: Build and Install Component
-      if: ${{ success() }}
       run: |
         cd ${{ inputs.app_install_dir }}
         echo "${{ inputs.component_build }}" >> install_comp.sh
@@ -158,7 +152,6 @@ runs:
 
     # use ESMX generic driver and create executable
     - name: Use ESMX to create executable
-      if: ${{ success() }}
       run: |
         $GITHUB_ACTION_PATH/scripts/create_exe.sh \
           -a ${{ inputs.app_install_dir }} \
@@ -171,7 +164,6 @@ runs:
     # restore input files from cache
     - name: Restore Input Files From Cache
       uses: actions/cache@v3
-      if: ${{ success() }}
       with:
         path: ${{ inputs.cache_input_file_list }}
         key: input-
@@ -181,7 +173,6 @@ runs:
     # create run directory and download input
     # no need to check the cache hit since script is able to check the existing files and not download again
     - name: Download Input Files
-      if: ${{ success() }}
       run: |
         export PATH=${{ inputs.dependencies_install_dir }}/view/bin:$PATH
         export PYTHONPATH=~/.local:$PYTHONPATH
@@ -194,7 +185,6 @@ runs:
 
     # generate configuration files
     - name: Generate Configuration Files
-      if: ${{ success() }}
       run: |
         export PYTHONPATH=$GITHUB_ACTION_PATH/scripts:$PYTHONPATH
         export PYTHONPATH=$GITHUB_ACTION_PATH/scripts/paramgen:$PYTHONPATH 
@@ -209,22 +199,22 @@ runs:
 
     # run application
     - name: Run Application
-      if: ${{ success() }}
       run: |
         export PATH=${{ inputs.dependencies_install_dir }}/view/bin:$PATH
         cd ${{ inputs.app_install_dir }}/run
         mpirun ${{ inputs.mpirun_args }} ${{ inputs.app_install_dir }}/build/esmx 2>&1 | tee out_err.txt
-        if [ $? -ne 0 ]; then
+        exc=$?
+        if [ $exc -ne 0 ]; then
           echo "Component did not run successfully! Partial output from PET log files: "
           tail -n 50 PET*
-          exit $?
+          exit $exc
         fi
       shell: bash {0}
 
     # upload model artifacts to check it later
     - name: Upload Artifacts
       uses: actions/upload-artifact@v3
-      if: ${{ success() }}
+      if: ${{ always() }}
       with:
         name: ${{ inputs.artifacts_name }}
         path: ${{ inputs.artifacts_files }}
@@ -232,7 +222,6 @@ runs:
 
     # find baseline date from cache, the most recent baseline will be picked
     - name: Query Date for Old Baseline From Cache
-      if: ${{ success() }}
       run: |
         # get date for old baseline
         BL_DATE_OLD=$(gh api -H "Accept: application/vnd.github+json" \
@@ -250,7 +239,6 @@ runs:
 
     # calculate hashes
     - name: Calculate Hashes of Output Files and Query Baseline Date
-      if: ${{ success() }}
       run: |
         # get current baseline date
         BL_DATE_OLD=${{ env.BL_DATE_OLD }}
@@ -288,7 +276,6 @@ runs:
     # restore baseline hash file and files from cache
     - name: Restore Baseline Hash File From Cache
       uses: actions/cache@v3
-      if: ${{ success() }}
       with:
         path: |
           ${{ inputs.app_install_dir }}/run/output_hash_baseline.txt
@@ -298,7 +285,6 @@ runs:
 
     # compare with the baseline
     - name: Compare with Baseline or Create New One
-      if: ${{ success() }}
       run: |
         cd ${{ inputs.app_install_dir }}/run
         # compare against the baseline, returns false if it does not match
@@ -320,7 +306,6 @@ runs:
 
     # Force to fail if the results are not matched with the baseline
     - name: Result of Baseline Check
-      if: ${{ success() }}
       run: |
         if [[ "${{ env.CHECK_RESULT }}" == "false" ]]; then
           echo "The results do not match with the baseline!"

--- a/action.yaml
+++ b/action.yaml
@@ -203,11 +203,11 @@ runs:
       run: |
         export PATH=${{ inputs.dependencies_install_dir }}/view/bin:$PATH
         cd ${{ inputs.app_install_dir }}/run
-        mpirun ${{ inputs.mpirun_args }} ${{ inputs.app_install_dir }}/build/esmx # 2>&1 | tee out_err.txt
+        mpirun ${{ inputs.mpirun_args }} ${{ inputs.app_install_dir }}/build/esmx >& out_err.txt
+        cat out_err.txt
         exc=$?
         if [ $exc -ne 0 ]; then
           echo "Component did not run successfully! Partial output from PET log files: "
-          cat out_err.txt
           tail -n 50 PET*
           exit $exc
         fi

--- a/action.yaml
+++ b/action.yaml
@@ -207,6 +207,7 @@ runs:
         exc=$?
         if [ $exc -ne 0 ]; then
           echo "Component did not run successfully! Partial output from PET log files: "
+          cat out_err.txt
           tail -n 50 PET*
           exit $exc
         fi

--- a/action.yaml
+++ b/action.yaml
@@ -47,6 +47,10 @@ inputs:
     description: data component name
     required: false
     default: datm
+  debug:
+    description: enable debug capability
+    required: false
+    default: OFF
   dependencies:
     description: list of packages to install
     required: true
@@ -198,7 +202,9 @@ runs:
         python3 $GITHUB_ACTION_PATH/scripts/gen_config.py --ifile ${{ inputs.test_definition }}
       shell: bash
 
-    - name: Setup tmate session
+    # used to debug run and allow ssh just before running the model
+    - name: Setup tmate session to allow ssh connection
+      if: ${{ inputs.debug == 'ON' }}
       uses: mxschmitt/action-tmate@v3
 
     # run application

--- a/action.yaml
+++ b/action.yaml
@@ -54,6 +54,7 @@ inputs:
   dependencies:
     description: list of packages to install
     required: true
+    type: string
   dependencies_install_dir:
     description: spack dependency installation directory
     required: false
@@ -88,6 +89,7 @@ runs:
     # concretize dependencies
     - name: Concretize Spack Environment Using YAML Specification
       run: |
+        echo "${{ inputs.dependencies }}"
         $GITHUB_ACTION_PATH/scripts/concretize_deps.sh \
           -a ${{ inputs.architecture }} \
           -c ${{ inputs.compiler }} \

--- a/action.yaml
+++ b/action.yaml
@@ -76,6 +76,7 @@ runs:
 
     # concretize dependencies
     - name: Concretize Spack Environment Using YAML Specification
+      if: failure()
       run: |
         $GITHUB_ACTION_PATH/scripts/concretize_deps.sh \
           -a ${{ inputs.architecture }} \
@@ -87,6 +88,7 @@ runs:
     # restore dependencies from cache
     - name: Restore Dependencies
       uses: actions/cache@v3
+      if: failure()
       with:
         path: ${{ inputs.dependencies_install_dir }} 
         key: spack-${{ runner.os }}-${{ inputs.architecture }}-${{ hashFiles('**/spack.lock') }}
@@ -95,6 +97,7 @@ runs:
 
     # install dependencies
     - name: Install Dependencies with Spack 
+      if: failure()
       run: |
         $GITHUB_ACTION_PATH/scripts/install_deps.sh \
           -i ${{ inputs.dependencies_install_dir }} \
@@ -104,6 +107,7 @@ runs:
     # checkout data models
     - name: Checkout CDEPS
       uses: actions/checkout@v3
+      if: failure()
       with:
         repository: uturuncoglu/CDEPS
         path: ${{ inputs.app_install_dir }}/cdeps
@@ -111,6 +115,7 @@ runs:
 
     # build and install data models
     - name: Build and Install CDEPS
+      if: failure()
       run: |
         export PATH=${{ inputs.dependencies_install_dir }}/view/bin:$PATH
         export ESMFMKFILE=${{ inputs.dependencies_install_dir }}/view/lib/esmf.mk
@@ -131,6 +136,7 @@ runs:
 
     # build component
     - name: Build and Install Component
+      if: failure()
       run: |
         cd ${{ inputs.app_install_dir }}
         echo "${{ inputs.component_build }}" >> install_comp.sh
@@ -140,6 +146,7 @@ runs:
 
     # use ESMX generic driver and create executable
     - name: Use ESMX to create executable
+      if: failure()
       run: |
         $GITHUB_ACTION_PATH/scripts/create_exe.sh \
           -a ${{ inputs.app_install_dir }} \
@@ -152,6 +159,7 @@ runs:
     # restore input files from cache
     - name: Restore Input Files From Cache
       uses: actions/cache@v3
+      if: failure()
       with:
         path: ${{ inputs.cache_input_file_list }}
         key: input-
@@ -161,6 +169,7 @@ runs:
     # create run directory and download input
     # no need to check the cache hit since script is able to check the existing files and not download again
     - name: Download Input Files
+      if: failure()
       run: |
         export PATH=${{ inputs.dependencies_install_dir }}/view/bin:$PATH
         export PYTHONPATH=~/.local:$PYTHONPATH
@@ -173,6 +182,7 @@ runs:
 
     # generate configuration files
     - name: Generate Configuration Files
+      if: failure()
       run: |
         export PYTHONPATH=$GITHUB_ACTION_PATH/scripts:$PYTHONPATH
         export PYTHONPATH=$GITHUB_ACTION_PATH/scripts/paramgen:$PYTHONPATH 
@@ -182,6 +192,7 @@ runs:
 
     # run application
     - name: Run Application
+      if: failure()
       run: |
         export PATH=${{ inputs.dependencies_install_dir }}/view/bin:$PATH
         cd ${{ inputs.app_install_dir }}/run
@@ -189,12 +200,14 @@ runs:
         if [ $? -ne 0 ]; then
           echo "Component did not run successfully! Partial output from PET log files: "
           tail -n 50 PET*
+          exit $?
         fi
       shell: bash {0}
 
     # upload model artifacts to check it later
     - name: Upload Artifacts
       uses: actions/upload-artifact@v3
+      if: failure()
       with:
         name: ${{ inputs.artifacts_name }}
         path: ${{ inputs.artifacts_files }}
@@ -202,6 +215,7 @@ runs:
 
     # find baseline date from cache, the most recent baseline will be picked
     - name: Query Date for Old Baseline From Cache
+      if: failure()
       run: |
         # get date for old baseline
         BL_DATE_OLD=$(gh api -H "Accept: application/vnd.github+json" \
@@ -219,6 +233,7 @@ runs:
 
     # calculate hashes
     - name: Calculate Hashes of Output Files and Query Baseline Date
+      if: failure()
       run: |
         # get current baseline date
         BL_DATE_OLD=${{ env.BL_DATE_OLD }}
@@ -256,6 +271,7 @@ runs:
     # restore baseline hash file and files from cache
     - name: Restore Baseline Hash File From Cache
       uses: actions/cache@v3
+      if: failure()
       with:
         path: |
           ${{ inputs.app_install_dir }}/run/output_hash_baseline.txt
@@ -265,6 +281,7 @@ runs:
 
     # compare with the baseline
     - name: Compare with Baseline or Create New One
+      if: failure()
       run: |
         cd ${{ inputs.app_install_dir }}/run
         # compare against the baseline, returns false if it does not match
@@ -286,6 +303,7 @@ runs:
 
     # Force to fail if the results are not matched with the baseline
     - name: Result of Baseline Check
+      if: failure()
       run: |
         if [[ "${{ env.CHECK_RESULT }}" == "false" ]]; then
           echo "The results do not match with the baseline!"

--- a/action.yaml
+++ b/action.yaml
@@ -91,7 +91,7 @@ runs:
         $GITHUB_ACTION_PATH/scripts/concretize_deps.sh \
           -a ${{ inputs.architecture }} \
           -c ${{ inputs.compiler }} \
-          -d $(echo "${{ inputs.dependencies }}" | awk '$1=$1' RS= OFS=,) \
+          -d $(echo "${{ inputs.dependencies }}" | awk '$1=$1' RS= OFS=":") \
           -i ${{ inputs.dependencies_install_dir }} \
           -r $GITHUB_WORKSPACE
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -76,7 +76,7 @@ runs:
 
     # concretize dependencies
     - name: Concretize Spack Environment Using YAML Specification
-      if: failure()
+      if: ${{ success() }}
       run: |
         $GITHUB_ACTION_PATH/scripts/concretize_deps.sh \
           -a ${{ inputs.architecture }} \
@@ -88,7 +88,7 @@ runs:
     # restore dependencies from cache
     - name: Restore Dependencies
       uses: actions/cache@v3
-      if: failure()
+      if: ${{ success() }}
       with:
         path: ${{ inputs.dependencies_install_dir }} 
         key: spack-${{ runner.os }}-${{ inputs.architecture }}-${{ hashFiles('**/spack.lock') }}
@@ -97,7 +97,7 @@ runs:
 
     # install dependencies
     - name: Install Dependencies with Spack 
-      if: failure()
+      if: ${{ success() }}
       run: |
         $GITHUB_ACTION_PATH/scripts/install_deps.sh \
           -i ${{ inputs.dependencies_install_dir }} \
@@ -107,7 +107,7 @@ runs:
     # checkout data models
     - name: Checkout CDEPS
       uses: actions/checkout@v3
-      if: failure()
+      if: ${{ success() }}
       with:
         repository: uturuncoglu/CDEPS
         path: ${{ inputs.app_install_dir }}/cdeps
@@ -115,7 +115,7 @@ runs:
 
     # build and install data models
     - name: Build and Install CDEPS
-      if: failure()
+      if: ${{ success() }}
       run: |
         export PATH=${{ inputs.dependencies_install_dir }}/view/bin:$PATH
         export ESMFMKFILE=${{ inputs.dependencies_install_dir }}/view/lib/esmf.mk
@@ -136,7 +136,7 @@ runs:
 
     # build component
     - name: Build and Install Component
-      if: failure()
+      if: ${{ success() }}
       run: |
         cd ${{ inputs.app_install_dir }}
         echo "${{ inputs.component_build }}" >> install_comp.sh
@@ -146,7 +146,7 @@ runs:
 
     # use ESMX generic driver and create executable
     - name: Use ESMX to create executable
-      if: failure()
+      if: ${{ success() }}
       run: |
         $GITHUB_ACTION_PATH/scripts/create_exe.sh \
           -a ${{ inputs.app_install_dir }} \
@@ -159,7 +159,7 @@ runs:
     # restore input files from cache
     - name: Restore Input Files From Cache
       uses: actions/cache@v3
-      if: failure()
+      if: ${{ success() }}
       with:
         path: ${{ inputs.cache_input_file_list }}
         key: input-
@@ -169,7 +169,7 @@ runs:
     # create run directory and download input
     # no need to check the cache hit since script is able to check the existing files and not download again
     - name: Download Input Files
-      if: failure()
+      if: ${{ success() }}
       run: |
         export PATH=${{ inputs.dependencies_install_dir }}/view/bin:$PATH
         export PYTHONPATH=~/.local:$PYTHONPATH
@@ -182,7 +182,7 @@ runs:
 
     # generate configuration files
     - name: Generate Configuration Files
-      if: failure()
+      if: ${{ success() }}
       run: |
         export PYTHONPATH=$GITHUB_ACTION_PATH/scripts:$PYTHONPATH
         export PYTHONPATH=$GITHUB_ACTION_PATH/scripts/paramgen:$PYTHONPATH 
@@ -192,7 +192,7 @@ runs:
 
     # run application
     - name: Run Application
-      if: failure()
+      if: ${{ success() }}
       run: |
         export PATH=${{ inputs.dependencies_install_dir }}/view/bin:$PATH
         cd ${{ inputs.app_install_dir }}/run
@@ -207,7 +207,7 @@ runs:
     # upload model artifacts to check it later
     - name: Upload Artifacts
       uses: actions/upload-artifact@v3
-      if: failure()
+      if: ${{ success() }}
       with:
         name: ${{ inputs.artifacts_name }}
         path: ${{ inputs.artifacts_files }}
@@ -215,7 +215,7 @@ runs:
 
     # find baseline date from cache, the most recent baseline will be picked
     - name: Query Date for Old Baseline From Cache
-      if: failure()
+      if: ${{ success() }}
       run: |
         # get date for old baseline
         BL_DATE_OLD=$(gh api -H "Accept: application/vnd.github+json" \
@@ -233,7 +233,7 @@ runs:
 
     # calculate hashes
     - name: Calculate Hashes of Output Files and Query Baseline Date
-      if: failure()
+      if: ${{ success() }}
       run: |
         # get current baseline date
         BL_DATE_OLD=${{ env.BL_DATE_OLD }}
@@ -271,7 +271,7 @@ runs:
     # restore baseline hash file and files from cache
     - name: Restore Baseline Hash File From Cache
       uses: actions/cache@v3
-      if: failure()
+      if: ${{ success() }}
       with:
         path: |
           ${{ inputs.app_install_dir }}/run/output_hash_baseline.txt
@@ -281,7 +281,7 @@ runs:
 
     # compare with the baseline
     - name: Compare with Baseline or Create New One
-      if: failure()
+      if: ${{ success() }}
       run: |
         cd ${{ inputs.app_install_dir }}/run
         # compare against the baseline, returns false if it does not match
@@ -303,7 +303,7 @@ runs:
 
     # Force to fail if the results are not matched with the baseline
     - name: Result of Baseline Check
-      if: failure()
+      if: ${{ success() }}
       run: |
         if [[ "${{ env.CHECK_RESULT }}" == "false" ]]; then
           echo "The results do not match with the baseline!"

--- a/action.yaml
+++ b/action.yaml
@@ -203,7 +203,7 @@ runs:
       run: |
         export PATH=${{ inputs.dependencies_install_dir }}/view/bin:$PATH
         cd ${{ inputs.app_install_dir }}/run
-        mpirun ${{ inputs.mpirun_args }} ${{ inputs.app_install_dir }}/build/esmx 2>&1 | tee out_err.txt
+        mpirun ${{ inputs.mpirun_args }} ${{ inputs.app_install_dir }}/build/esmx # 2>&1 | tee out_err.txt
         exc=$?
         if [ $exc -ne 0 ]; then
           echo "Component did not run successfully! Partial output from PET log files: "

--- a/action.yaml
+++ b/action.yaml
@@ -90,11 +90,11 @@ runs:
       run: |
         echo "${{ inputs.dependencies }}"
         $GITHUB_ACTION_PATH/scripts/concretize_deps.sh \
-          -a "${{ inputs.architecture }}" \
-          -c "${{ inputs.compiler }}" \
+          -a ${{ inputs.architecture }} \
+          -c ${{ inputs.compiler }} \
           -d "$(echo "${{ inputs.dependencies }}" | sed -z 's/\n/:/g' | sed 's/:$//')" \
-          -i "${{ inputs.dependencies_install_dir }}" \
-          -r "$GITHUB_WORKSPACE"
+          -i ${{ inputs.dependencies_install_dir }} \
+          -r $GITHUB_WORKSPACE
       shell: bash
 
     # restore dependencies from cache
@@ -155,11 +155,11 @@ runs:
     - name: Use ESMX to create executable
       run: |
         $GITHUB_ACTION_PATH/scripts/create_exe.sh \
-          -a "${{ inputs.app_install_dir }}" \
-          -d "${{ inputs.data_component_name }}" \
-          -i "${{ inputs.dependencies_install_dir }}" \
-          -m "${{ inputs.component_name }}" \
-          -n "${{ inputs.component_module_name }}"
+          -a ${{ inputs.app_install_dir }} \
+          -d ${{ inputs.data_component_name }} \
+          -i ${{ inputs.dependencies_install_dir }} \
+          -m ${{ inputs.component_name }} \
+          -n ${{ inputs.component_module_name }}
       shell: bash
 
     # restore input files from cache

--- a/action.yaml
+++ b/action.yaml
@@ -97,6 +97,7 @@ runs:
     - name: Install Dependencies with Spack 
       run: |
         $GITHUB_ACTION_PATH/scripts/install_deps.sh \
+          -i ${{ inputs.dependencies_install_dir }} \
           -r $GITHUB_WORKSPACE
       shell: bash
 

--- a/action.yaml
+++ b/action.yaml
@@ -198,6 +198,9 @@ runs:
         python3 $GITHUB_ACTION_PATH/scripts/gen_config.py --ifile ${{ inputs.test_definition }}
       shell: bash
 
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+
     # run application
     - name: Run Application
       if: ${{ success() }}

--- a/action.yaml
+++ b/action.yaml
@@ -93,7 +93,7 @@ runs:
         $GITHUB_ACTION_PATH/scripts/concretize_deps.sh \
           -a "${{ inputs.architecture }}" \
           -c "${{ inputs.compiler }}" \
-          -d "$(echo ${{ inputs.dependencies }} | sed -z 's/\n/:/g;s/:$//')" \
+          -d "$(echo "${{ inputs.dependencies }}" | sed -z 's/\n/:/g;s/:$//')" \
           -i "${{ inputs.dependencies_install_dir }}" \
           -r "$GITHUB_WORKSPACE"
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -50,6 +50,9 @@ inputs:
     description: spack dependency installation directory
     required: false
     default: ~/.spack-ci
+  mpirun_args:
+    description: atguments that will be used in mpirun command
+    required: true
   test_definition:
     description: YAML file that describes the test
     required: true
@@ -196,7 +199,7 @@ runs:
       run: |
         export PATH=${{ inputs.dependencies_install_dir }}/view/bin:$PATH
         cd ${{ inputs.app_install_dir }}/run
-        mpirun --oversubscribe -np 6 --allow-run-as-root ${{ inputs.app_install_dir }}/build/esmx 2>&1 | tee out_err.txt
+        mpirun ${{ inputs.mpirun_args }} ${{ inputs.app_install_dir }}/build/esmx 2>&1 | tee out_err.txt
         if [ $? -ne 0 ]; then
           echo "Component did not run successfully! Partial output from PET log files: "
           tail -n 50 PET*

--- a/action.yaml
+++ b/action.yaml
@@ -93,7 +93,7 @@ runs:
         $GITHUB_ACTION_PATH/scripts/concretize_deps.sh \
           -a "${{ inputs.architecture }}" \
           -c "${{ inputs.compiler }}" \
-          -d "$(echo "${{ inputs.dependencies }}" | sed -z 's/\n/:/g;s/:$//')" \
+          -d "$(echo "${{ inputs.dependencies }}" | sed -z 's/\n/:/g' | sed 's/:$//')" \
           -i "${{ inputs.dependencies_install_dir }}" \
           -r "$GITHUB_WORKSPACE"
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -91,7 +91,7 @@ runs:
         $GITHUB_ACTION_PATH/scripts/concretize_deps.sh \
           -a ${{ inputs.architecture }} \
           -c ${{ inputs.compiler }} \
-          -d $(echo "${{ inputs.dependencies }}" | awk '$1=$1' RS= OFS=":") \
+          -d $(echo "${{ inputs.dependencies }}" | sed -z 's/\n/:/g;s/:$//') \
           -i ${{ inputs.dependencies_install_dir }} \
           -r $GITHUB_WORKSPACE
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -91,11 +91,11 @@ runs:
       run: |
         echo "${{ inputs.dependencies }}"
         $GITHUB_ACTION_PATH/scripts/concretize_deps.sh \
-          -a ${{ inputs.architecture }} \
-          -c ${{ inputs.compiler }} \
-          -d $(echo "${{ inputs.dependencies }}" | sed -z 's/\n/:/g;s/:$//') \
-          -i ${{ inputs.dependencies_install_dir }} \
-          -r $GITHUB_WORKSPACE
+          -a "${{ inputs.architecture }}" \
+          -c "${{ inputs.compiler }}" \
+          -d "$(echo ${{ inputs.dependencies }} | sed -z 's/\n/:/g;s/:$//')" \
+          -i "${{ inputs.dependencies_install_dir }}" \
+          -r "$GITHUB_WORKSPACE"
       shell: bash
 
     # restore dependencies from cache
@@ -111,8 +111,8 @@ runs:
     - name: Install Dependencies with Spack 
       run: |
         $GITHUB_ACTION_PATH/scripts/install_deps.sh \
-          -i ${{ inputs.dependencies_install_dir }} \
-          -r $GITHUB_WORKSPACE
+          -i "${{ inputs.dependencies_install_dir }}" \
+          -r "$GITHUB_WORKSPACE"
       shell: bash
 
     # checkout data models
@@ -156,11 +156,11 @@ runs:
     - name: Use ESMX to create executable
       run: |
         $GITHUB_ACTION_PATH/scripts/create_exe.sh \
-          -a ${{ inputs.app_install_dir }} \
-          -d ${{ inputs.data_component_name }} \
-          -i ${{ inputs.dependencies_install_dir }} \
-          -m ${{ inputs.component_name }} \
-          -n ${{ inputs.component_module_name }}
+          -a "${{ inputs.app_install_dir }}" \
+          -d "${{ inputs.data_component_name }}" \
+          -i "${{ inputs.dependencies_install_dir }}" \
+          -m "${{ inputs.component_name }}" \
+          -n "${{ inputs.component_module_name }}"
       shell: bash
 
     # restore input files from cache

--- a/action.yaml
+++ b/action.yaml
@@ -54,7 +54,6 @@ inputs:
   dependencies:
     description: list of packages to install
     required: true
-    type: string
   dependencies_install_dir:
     description: spack dependency installation directory
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -29,6 +29,10 @@ inputs:
   cache_input_file_list:
     description: list of input files that needs to be cached
     required: false
+  compiler:
+    description: compiler that will be used
+    required: false
+    default: gcc@11.3.0
   component_name:
     description: component name
     required: false
@@ -83,6 +87,7 @@ runs:
       run: |
         $GITHUB_ACTION_PATH/scripts/concretize_deps.sh \
           -a ${{ inputs.architecture }} \
+          -c ${{ inputs.compiler }} \
           -d $(echo "${{ inputs.dependencies }}" | awk '$1=$1' RS= OFS=,) \
           -i ${{ inputs.dependencies_install_dir }} \
           -r $GITHUB_WORKSPACE

--- a/scripts/concretize_deps.sh
+++ b/scripts/concretize_deps.sh
@@ -30,7 +30,7 @@ if [[ -z "$run_dir" || ! -z `echo $run_dir | grep '^-'` ]]; then
 fi
 
 if [[ -z "$arch" || ! -z `echo $arch | grep '^-'` ]]; then
-  arch="x86_64_v4"
+  arch="x86_64"
 fi
 
 # print out arguments
@@ -45,9 +45,6 @@ cd $run_dir
 # checkout spack
 echo "::group::Checkout Spack"
 git clone https://github.com/spack/spack.git
-cd spack
-git checkout 15f7b72557a9c56d66327daf49284fc22cb4bc8d
-cd -
 echo "::endgroup::"
 
 # create spack.yaml

--- a/scripts/concretize_deps.sh
+++ b/scripts/concretize_deps.sh
@@ -68,7 +68,7 @@ echo "      granularity: generic" >> spack.yaml
 echo "      host_compatible: false" >> spack.yaml
 echo "    unify: when_possible" >> spack.yaml
 echo "  specs:" >> spack.yaml
-IFS=': ' read -r -a array <<< "$deps"
+IFS=':' read -r -a array <<< "$deps"
 echo "${array[@]}"
 for d in "${array[@]}"
 do

--- a/scripts/concretize_deps.sh
+++ b/scripts/concretize_deps.sh
@@ -111,8 +111,9 @@ echo "::endgroup::"
 # concretize spack environment
 echo "::group::Concretize Spack Environment Using YAML Specification"
 spack --color always -e $run_dir/. concretize -f
-if [ $? -ne 0 ]; then
-  echo "Error in concretize step! exiting ..."
-  exit $?
+exc=$?
+if [ $exc -ne 0 ]; then
+  echo "Error in concretizing dependencies! exit code is $exc ..."
+  exit $exc
 fi
 echo "::endgroup::"

--- a/scripts/concretize_deps.sh
+++ b/scripts/concretize_deps.sh
@@ -4,11 +4,11 @@
 while getopts a:c:d:i:r: flag
 do
   case "${flag}" in
-    a) arch="${OPTARG}";;
-    c) comp="${OPTARG}";;
+    a) arch=${OPTARG};;
+    c) comp=${OPTARG};;
     d) deps="${OPTARG}";;
-    i) install_dir="${OPTARG}";;
-    r) run_dir="${OPTARG}";;
+    i) install_dir=${OPTARG};;
+    r) run_dir=${OPTARG};;
   esac
 done
 
@@ -69,7 +69,6 @@ echo "      host_compatible: false" >> spack.yaml
 echo "    unify: when_possible" >> spack.yaml
 echo "  specs:" >> spack.yaml
 IFS=':' read -r -a array <<< "$deps"
-echo "${array[@]}"
 for d in "${array[@]}"
 do
   echo "  - $d %$comp target=$arch" >> spack.yaml

--- a/scripts/concretize_deps.sh
+++ b/scripts/concretize_deps.sh
@@ -51,11 +51,15 @@ cd $run_dir
 # checkout spack and setup to use it
 echo "::group::Checkout Spack"
 git clone https://github.com/spack/spack.git
+# checkout specific version of spack beacuse https://github.com/spack/spack/pull/37438
+# introduces a bug that prevents to install package tags that are not included package.py
+cd spack
+git checkout b2c3973 
+cd -
 . spack/share/spack/setup-env.sh
 echo "::endgroup::"
 
 # find compilers
-. spack/share/spack/setup-env.sh
 spack compiler find
 cat ~/.spack/linux/compilers.yaml
 echo "::endgroup::"

--- a/scripts/concretize_deps.sh
+++ b/scripts/concretize_deps.sh
@@ -4,11 +4,11 @@
 while getopts a:c:d:i:r: flag
 do
   case "${flag}" in
-    a) arch=${OPTARG};;
-    c) comp=${OPTARG};;
-    d) deps=${OPTARG};;
-    i) install_dir=${OPTARG};;
-    r) run_dir=${OPTARG};;
+    a) arch="${OPTARG}";;
+    c) comp="${OPTARG}";;
+    d) deps="${OPTARG}";;
+    i) install_dir="${OPTARG}";;
+    r) run_dir="${OPTARG}";;
   esac
 done
 

--- a/scripts/concretize_deps.sh
+++ b/scripts/concretize_deps.sh
@@ -51,11 +51,6 @@ cd $run_dir
 # checkout spack and setup to use it
 echo "::group::Checkout Spack"
 git clone https://github.com/spack/spack.git
-# checkout specific version of spack beacuse https://github.com/spack/spack/pull/37438
-# introduces a bug that prevents to install package tags that are not included package.py
-cd spack
-git checkout b2c3973 
-cd -
 . spack/share/spack/setup-env.sh
 echo "::endgroup::"
 
@@ -74,6 +69,7 @@ echo "      host_compatible: false" >> spack.yaml
 echo "    unify: when_possible" >> spack.yaml
 echo "  specs:" >> spack.yaml
 IFS=', ' read -r -a array <<< "$deps"
+echo "${array[@]}"
 for d in "${array[@]}"
 do
   echo "  - $d %$comp target=$arch" >> spack.yaml
@@ -94,6 +90,8 @@ echo "      root: $install_dir/opt" >> spack.yaml
 echo "    install_missing_compilers: true" >> spack.yaml
 cat spack.yaml
 echo "::endgroup::"
+
+exit -1
 
 # find external tools
 echo "::group::Find Externals"

--- a/scripts/concretize_deps.sh
+++ b/scripts/concretize_deps.sh
@@ -68,7 +68,7 @@ echo "      granularity: generic" >> spack.yaml
 echo "      host_compatible: false" >> spack.yaml
 echo "    unify: when_possible" >> spack.yaml
 echo "  specs:" >> spack.yaml
-IFS=', ' read -r -a array <<< "$deps"
+IFS=': ' read -r -a array <<< "$deps"
 echo "${array[@]}"
 for d in "${array[@]}"
 do

--- a/scripts/concretize_deps.sh
+++ b/scripts/concretize_deps.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 # get arguments
-while getopts a:d:i:r: flag
+while getopts a:c:d:i:r: flag
 do
   case "${flag}" in
     a) arch=${OPTARG};;
+    c) comp=${OPTARG};;
     d) deps=${OPTARG};;
     i) install_dir=${OPTARG};;
     r) run_dir=${OPTARG};;
@@ -33,8 +34,13 @@ if [[ -z "$arch" || ! -z `echo $arch | grep '^-'` ]]; then
   arch="x86_64"
 fi
 
+if [[ -z "$comp" || ! -z `echo $comp | grep '^-'` ]]; then
+  comp="gcc@11.3.0"
+fi
+
 # print out arguments
 echo "Target Architecture: $arch"
+echo "Compiler: $comp"
 echo "Dependencies: $deps";
 echo "Install Directory: $install_dir";
 echo "Run Directory: $run_dir";
@@ -42,9 +48,16 @@ echo "Run Directory: $run_dir";
 # go to directory
 cd $run_dir
 
-# checkout spack
+# checkout spack and setup to use it
 echo "::group::Checkout Spack"
 git clone https://github.com/spack/spack.git
+. spack/share/spack/setup-env.sh
+echo "::endgroup::"
+
+# find compilers
+. spack/share/spack/setup-env.sh
+spack compiler find
+cat ~/.spack/linux/compilers.yaml
 echo "::endgroup::"
 
 # create spack.yaml
@@ -59,15 +72,14 @@ echo "  specs:" >> spack.yaml
 IFS=', ' read -r -a array <<< "$deps"
 for d in "${array[@]}"
 do
-  echo "  - $d target=$arch" >> spack.yaml
+  echo "  - $d %$comp target=$arch" >> spack.yaml
 done
 echo "  packages:" >> spack.yaml
 echo "    all:" >> spack.yaml
 # following is required to build same optimized spack for different github action runners
 # spack arch --known-targets command can be used to list known targets
 echo "      target: ['$arch']" >> spack.yaml
-# following fixes compiler version
-echo "      compiler: [gcc@11.3.0]" >> spack.yaml
+echo "      compiler: [$comp]" >> spack.yaml
 echo "  view: $install_dir/view" >> spack.yaml
 echo "  config:" >> spack.yaml
 echo "    source_cache: $install_dir/source_cache" >> spack.yaml
@@ -75,11 +87,28 @@ echo "    misc_cache: $install_dir/misc_cache" >> spack.yaml
 echo "    test_cache: $install_dir/test_cache" >> spack.yaml
 echo "    install_tree:" >> spack.yaml
 echo "      root: $install_dir/opt" >> spack.yaml
+echo "    install_missing_compilers: true" >> spack.yaml
 cat spack.yaml
+echo "::endgroup::"
+
+# find external tools
+echo "::group::Find Externals"
+spack external find
+echo "::endgroup::"
+
+# create config file (to fix FetchError issue)
+echo "::group::Create config.yaml"
+echo "config:" > ~/.spack/config.yaml
+echo "  url_fetch_method: curl" >> ~/.spack/config.yaml
+echo "  connect_timeout: 60" >> ~/.spack/config.yaml
+cat ~/.spack/config.yaml
 echo "::endgroup::"
 
 # concretize spack environment
 echo "::group::Concretize Spack Environment Using YAML Specification"
-. spack/share/spack/setup-env.sh
 spack --color always -e $run_dir/. concretize -f
+if [ $? -ne 0 ]; then
+  echo "Error in concretize step! exiting ..."
+  exit $?
+fi
 echo "::endgroup::"

--- a/scripts/concretize_deps.sh
+++ b/scripts/concretize_deps.sh
@@ -44,7 +44,10 @@ cd $run_dir
 
 # checkout spack
 echo "::group::Checkout Spack"
-git clone -b jcsda_emc_spack_stack https://github.com/NOAA-EMC/spack.git
+git clone https://github.com/spack/spack.git
+cd spack
+git checkout 15f7b72557a9c56d66327daf49284fc22cb4bc8d
+cd -
 echo "::endgroup::"
 
 # create spack.yaml

--- a/scripts/concretize_deps.sh
+++ b/scripts/concretize_deps.sh
@@ -91,8 +91,6 @@ echo "    install_missing_compilers: true" >> spack.yaml
 cat spack.yaml
 echo "::endgroup::"
 
-exit -1
-
 # find external tools
 echo "::group::Find Externals"
 spack external find

--- a/scripts/create_exe.sh
+++ b/scripts/create_exe.sh
@@ -72,6 +72,11 @@ cat esmxBuild.yaml
 
 # create build directory
 cmake -H$ESMF_ESMXDIR -Bbuild
+exc=$?
+if [ $exc -ne 0 ]; then
+  echo "Error when creating executable! exit code is $exc ..."
+  exit $exc
+fi
 
 # compile and create executable
 cd $app_install_dir/build

--- a/scripts/get_input.py
+++ b/scripts/get_input.py
@@ -44,6 +44,15 @@ def recv_files(_dict, fhash, force_download):
             else:
                 sys.exit('Files are not listed for component {} and section {}!'.format(k1, k2))
 
+            if 'force' in v2:
+                force = v2['force']
+            else:
+                force = False
+
+            # overwrite force download using YAML
+            if force:
+                force_download = True
+
             # save current directory
             current_dir = os.getcwd()
 

--- a/scripts/get_input.py
+++ b/scripts/get_input.py
@@ -52,6 +52,7 @@ def recv_files(_dict, fhash, force_download):
             # overwrite force download using YAML
             if force:
                 force_download = True
+                print('Force download of {}!'.format(files))
 
             # save current directory
             current_dir = os.getcwd()

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # get arguments
-while getopts r: flag
+while getopts i:r: flag
 do
   case "${flag}" in
     i) install_dir=${OPTARG};;

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -28,6 +28,11 @@ cd $run_dir
 echo "::group::Install Spack Packages"
 . spack/share/spack/setup-env.sh
 spack --color always -e $run_dir/. install -j3 --deprecated --no-checksum
+exc=$?
+if [ $exc -ne 0 ]; then
+  echo "Error in installing dependencies! exit code is $exc ..."
+  exit $exc
+fi
 echo "::endgroup::"
 
 # output esmf.mk file for debugging

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -4,11 +4,16 @@
 while getopts r: flag
 do
   case "${flag}" in
+    i) install_dir=${OPTARG};;
     r) run_dir=${OPTARG};;
   esac
 done
 
 # check for default values
+if [[ -z "$install_dir" || ! -z `echo $install_dir | grep '^-'` ]]; then
+  install_dir="$HOME/.spack-ci"
+fi
+
 if [[ -z "$run_dir" || ! -z `echo $run_dir | grep '^-'` ]]; then
   run_dir=`pwd`
 fi
@@ -23,4 +28,9 @@ cd $run_dir
 echo "::group::Install Spack Packages"
 . spack/share/spack/setup-env.sh
 spack --color always -e $run_dir/. install -j3 --deprecated --no-checksum
+echo "::endgroup::"
+
+# output esmf.mk file for debugging
+echo "::group::Content of esmf.mk"
+cat $install_dir/view/lib/esmf.mk
 echo "::endgroup::"


### PR DESCRIPTION
The PR brings new features to component testing listed as follows,

* The extra `mpirun` arguments now need to be passed with `mpirun_arg` input argument.
* A new `debug` argument is added to the action that allow to create ssh connection to the runner for debugging (uses mxschmitt/action-tmate@v3).
* Now uses authoritative [Spack repository](https://github.com/spack/spack.git).
* Spack now uses `curl` to download packages and timeout limit is increased to 60 s to prevent fetching issues
* Spack now could use system installed packages (`spack external find`).

This is the last version before starting to support ESMF 8.5.0 release (has improved version of ESMX).

Fixes:

- Closes https://github.com/esmf-org/nuopc-comp-testing/issues/2